### PR TITLE
Use {name} as a rule for oceanus internationalization close #23

### DIFF
--- a/style.json
+++ b/style.json
@@ -875,13 +875,7 @@
           "Noto Sans Regular"
         ],
         "text-size": 14,
-        "text-field": [
-          "to-string",
-          [
-            "get",
-            "name"
-          ]
-        ],
+        "text-field": "{name}",
         "text-max-width": 5,
         "text-rotation-alignment": "map",
         "symbol-placement": "point",
@@ -931,13 +925,7 @@
           6,
           14
         ],
-        "text-field": [
-          "to-string",
-          [
-            "get",
-            "name"
-          ]
-        ],
+        "text-field": "{name}",
         "text-max-width": 5,
         "text-rotation-alignment": "map",
         "symbol-placement": "point",
@@ -970,13 +958,7 @@
           "Noto Sans Regular"
         ],
         "text-size": 14,
-        "text-field": [
-          "to-string",
-          [
-            "get",
-            "name"
-          ]
-        ],
+        "text-field": "{name}",
         "text-max-width": 5,
         "text-rotation-alignment": "map",
         "symbol-placement": "point",
@@ -1008,13 +990,7 @@
           "Noto Sans Regular"
         ],
         "text-size": 14,
-        "text-field": [
-          "to-string",
-          [
-            "get",
-            "name"
-          ]
-        ],
+        "text-field": "{name}",
         "text-max-width": 5,
         "text-rotation-alignment": "map",
         "symbol-placement": "point",
@@ -3566,13 +3542,7 @@
           "Noto Sans Regular"
         ],
         "text-size": 14,
-        "text-field": [
-          "to-string",
-          [
-            "get",
-            "name"
-          ]
-        ],
+        "text-field": "{name}",
         "text-max-width": 8,
         "visibility": "visible"
       },
@@ -3614,13 +3584,7 @@
         ],
         "icon-image": "circle-11",
         "icon-allow-overlap": true,
-        "text-field": [
-          "to-string",
-          [
-            "get",
-            "name"
-          ]
-        ],
+        "text-field": "{name}",
         "text-offset": [
           0.6,
           0.6
@@ -3662,13 +3626,7 @@
           "Noto Sans Regular"
         ],
         "text-size": 14,
-        "text-field": [
-          "to-string",
-          [
-            "get",
-            "name"
-          ]
-        ],
+        "text-field": "{name}",
         "text-max-width": 8,
         "visibility": "visible"
       },
@@ -3708,13 +3666,7 @@
           "Noto Sans Regular"
         ],
         "text-size": 14,
-        "text-field": [
-          "to-string",
-          [
-            "get",
-            "name"
-          ]
-        ],
+        "text-field": "{name}",
         "text-max-width": 8,
         "visibility": "visible"
       },
@@ -3761,13 +3713,7 @@
         ],
         "text-anchor": "top",
         "icon-image": "circle-11",
-        "text-field": [
-          "to-string",
-          [
-            "get",
-            "name"
-          ]
-        ],
+        "text-field": "{name}",
         "text-offset": [
           0,
           0.6
@@ -3814,13 +3760,7 @@
         ],
         "text-anchor": "top",
         "icon-image": "circle-11",
-        "text-field": [
-          "to-string",
-          [
-            "get",
-            "name"
-          ]
-        ],
+        "text-field": "{name}",
         "text-offset": [
           0,
           0.6


### PR DESCRIPTION
cdn 配信用に英語版のスタイルが正しく生成できるように、ルールとして `"{name}"` を使うように修正。